### PR TITLE
关于脚本可运行性问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ To achieve this goal, following the steps as follow:
 4. Open the .txt file right next to the scirpt and select all then copy.
 Note: the API 163 provided only enable me to retrive 1000 songs in your playlist. 
 
+
+
 # 网易云音乐Spider
 程序旨在帮助你爬取到，网易云上你喜欢的歌单的所有的歌曲信息。
 步骤如下：
@@ -15,6 +17,8 @@ Note: the API 163 provided only enable me to retrive 1000 songs in your playlist
 3. 双击脚本，运行脚本。你只需要运行和你的本地Python版本一样的脚本即可。
 4. 歌单保存到本地的.txt文件中。
 注意：网易云音乐歌单只允许加载1000首歌曲。
+
+
 
 # 其他教程
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
-# 163MusicToSpotify
-This tiny program enables you to convert your favorite 163 music playlist to Spotify
-To convert, following the steps as follow:
-1. go get the id of your 163 playlist. to get it open the page of the playlist in a browser then copy the numbers behind "music.163.com/#/playlist?id=" in address bar. 
-2. download t.py to your computer and make sure there are python installed.
-3. right click the file and edit it. **paste the playlist id to playlistId vairable so that it can convert the playlist.**
-4. double click to run it.
-5. open the txt file right next to the t.py and select all then copy.
-6. open [this site](http://spotlistr.herokuapp.com/#/search/textbox) and paste the text. Following steps are all proceeded on that site. 
-
+# 163MusicSpider
+This tiny program enables you to download your favorite 163 music playlists.
+To achieve this goal, following the steps as follow:
+1. Go get the id of your 163 playlist. to get it open the page of the playlist in a browser then copy the numbers behind "music.163.com/#/playlist?id=" in address bar. 
+2. Download the python script to your computer and make sure there are python installed.
+3. Run the script by double clicking it. Be careful. You just need to run the script whose name is matched with your local Python version.
+4. Open the .txt file right next to the scirpt and select all then copy.
 Note: the API 163 provided only enable me to retrive 1000 songs in your playlist. 
+
+# 网易云音乐Spider
+程序旨在帮助你爬取到，网易云上你喜欢的歌单的所有的歌曲信息。
+步骤如下：
+1. 在浏览器打开你的网易云歌单，复制你的歌单网址中，位于 "music.163.com/#/playlist?id=" 后方的数字。
+2. 下载本脚本，并且确保本地机器已安装Python
+3. 双击脚本，运行脚本。你只需要运行和你的本地Python版本一样的脚本即可。
+4. 歌单保存到本地的.txt文件中。
+注意：网易云音乐歌单只允许加载1000首歌曲。
+
+# 其他教程
 
 ## 如何将spotify歌单导入网易云音乐？
 关于这一点，虽然网上已经有不少方法，但是大多还需要自己手动更改不少东西，总体来说十分麻烦。之前在简书上找到的[方法](http://www.jianshu.com/p/21bafe882455)也已经失效了。但原理一般都是利用网易提供的导入酷狗歌单（.KGL）文件进行导入，依葫芦画瓢，写了个很小的程序，具体的操作如下：

--- a/python2.py
+++ b/python2.py
@@ -1,5 +1,6 @@
 import json
 import sys
+from urllib import urlopen
 
 enterId = 'Enter the playlist id (Enter ? to get help):'
 help = 'To get the id of the playlist, go to the page\
@@ -9,15 +10,7 @@ of it and look at the address bar.\
 errRetrive = 'No data retrived. \nPlease check the playlist id again.'
 
 while 1:
-	if sys.version_info[0] == 3:
-		playlistId = input(enterId)
-		from urllib.request import urlopen
-	else:
-		# Not Python 3 - today, it is most likely to be Python 2
-		# But note that this might need an update when Python 4
-		# might be around one day
-		playlistId = raw_input(enterId)
-		from urllib import urlopen
+	playlistId = raw_input(enterId)
 
 	#change the playlistId variable 
 	if playlistId == '?':
@@ -25,11 +18,7 @@ while 1:
 	urladd = "http://music.163.com/api/playlist/detail?id="\
 		+ str(playlistId) + "&updateTime=-1"
 	# Your code where you can use urlopen
-	if sys.version_info[0] == 3:
-		with urlopen(urladd) as url:
-			response = url.read()
-	else:
-		response = urlopen(urladd).read()
+	response = urlopen(urladd).read()
 	data = json.loads(response)
 
 	output = ""
@@ -45,13 +34,8 @@ while 1:
 		artist = track["artists"][0]["name"]
 		output += trackName + ' - ' + artist + '\n'
 	playlistName = data["result"]["name"]
+	
+	with open(playlistName + '.txt', 'w') as file:
+		file.write(output.encode('utf8'))
 
-	if sys.version_info[0] == 3:
-		with open(playlistName + '.txt', 'wb') as file:
-			file.write(output.encode('utf8'))
-			file.close
-	else:
-		with open(playlistName + '.txt', 'w') as file:
-			file.write(output.encode('utf8'))
-			file.close
 	print('Success.\nCheck the directory of this file and find the .kgl file!')

--- a/python3.py
+++ b/python3.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+import json
+import sys, io
+from urllib.request import urlopen
+enterId = 'Enter the playlist id (Enter ? to get help):'
+help = 'To get the id of the playlist, go to the page\
+of it and look at the address bar.\
+ \nPlaylist id is the numbers after \
+ "http://music.163.com/#/playlist?id="'
+errRetrive = 'No data retrived. \nPlease check the playlist id again.'
+
+while 1:
+	playlistId = 85644225
+
+	#change the playlistId variable 
+	if playlistId == '?':
+		print
+	urladd = "http://music.163.com/api/playlist/detail?id="\
+		+ str(playlistId) + "&updateTime=-1"
+	# Your code where you can use urlopen
+	with urlopen(urladd) as url:
+		response = url.read().decode('utf-8')
+	data = json.loads(response)
+
+	if "result" not in data:
+		print(errRetrive)
+		print(help)
+		continue
+		
+	tracks = data["result"]["tracks"]
+
+
+	with open('list.txt', 'w',encoding='utf-8') as file:
+		for track in tracks:
+			trackName = track["name"]
+			artist = track["artists"][0]["name"]
+			file.write(trackName+"@"+artist+"\n")
+
+	print('Success.\nCheck the directory of this file and find the .kgl file!')
+	break

--- a/python3.py
+++ b/python3.py
@@ -2,6 +2,7 @@
 import json
 import sys, io
 from urllib.request import urlopen
+
 enterId = 'Enter the playlist id (Enter ? to get help):'
 help = 'To get the id of the playlist, go to the page\
 of it and look at the address bar.\
@@ -10,7 +11,7 @@ of it and look at the address bar.\
 errRetrive = 'No data retrived. \nPlease check the playlist id again.'
 
 while 1:
-	playlistId = 85644225
+	playlistId = 
 
 	#change the playlistId variable 
 	if playlistId == '?':
@@ -22,19 +23,22 @@ while 1:
 		response = url.read().decode('utf-8')
 	data = json.loads(response)
 
+	output = ""
+
 	if "result" not in data:
 		print(errRetrive)
 		print(help)
 		continue
 		
 	tracks = data["result"]["tracks"]
+	for track in tracks:
+		trackName = track["name"]
+		artist = track["artists"][0]["name"]
+		output += trackName + ' - ' + artist + '\n'
+	playlistName = data["result"]["name"]
 
 
-	with open('list.txt', 'w',encoding='utf-8') as file:
-		for track in tracks:
-			trackName = track["name"]
-			artist = track["artists"][0]["name"]
-			file.write(trackName+"@"+artist+"\n")
+	with open(playlistName+'.txt', 'w',encoding='utf-8') as file:
+		file.write(output)
 
 	print('Success.\nCheck the directory of this file and find the .kgl file!')
-	break

--- a/python3.py
+++ b/python3.py
@@ -11,7 +11,7 @@ of it and look at the address bar.\
 errRetrive = 'No data retrived. \nPlease check the playlist id again.'
 
 while 1:
-	playlistId = 
+	playlistId = input(enterId)
 
 	#change the playlistId variable 
 	if playlistId == '?':


### PR DESCRIPTION
原脚本在Python3上不可运行，主要原因在于Python3对字符有大量调整，而原脚本不能很好地处理这些调整。
所以这里发布一个完全新版的python3.py，专门针对python 3.0+的用户使用。